### PR TITLE
feat: brokerage login volume prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,47 @@ A web UI displays the live event feed, classification summary, an AI-generated n
 
 ## How it works
 
+
+### From signals to prediction
+
+Sentinel combines two independent data streams — financial news and global market data — into a single brokerage login volume prediction. News articles are classified by market impact (HIGH / MEDIUM / LOW) and assigned a financial sentiment (POSITIVE / NEGATIVE / NEUTRAL) by a local Ollama LLM. In parallel, global index quotes from yfinance are evaluated for volatility, detecting significant single-index moves and cross-market correlations. Both streams feed a composite scoring engine that produces the Brokerage Login Prediction visible at the top of the Dashboard.
+
+```mermaid
+flowchart LR
+    A["News Article<br/>(RSS / NewsAPI)"]
+    M["Global Market Data<br/>(yfinance)"]
+    P["Brokerage Login Prediction<br/>(NORMAL / MODERATE / ELEVATED / SURGE)"]
+
+    subgraph impact["Impact Classification"]
+        B1["HIGH<br/>Broad market event"]
+        B2["MEDIUM<br/>Company-specific"]
+        B3["LOW<br/>Commentary / noise"]
+    end
+
+    subgraph sentiment["Financial Sentiment"]
+        C1["POSITIVE<br/>Encourages buying"]
+        C2["NEGATIVE<br/>Triggers concern"]
+        C3["NEUTRAL<br/>Ambiguous"]
+    end
+
+    subgraph volatility["Volatility Signals"]
+        V1["HIGH<br/>Index move ≥ 2%"]
+        V2["MEDIUM<br/>Index move ≥ 1%"]
+        V3["Cross-market<br/>Correlation"]
+    end
+
+    A --> B1 & B2 & B3
+    B1 & B2 & B3 --> C1 & C2 & C3
+    M --> V1 & V2 & V3
+
+    C1 & C2 & C3 --> P
+    V1 & V2 & V3 --> P
+```
+
+The spike detection mirrors a login-volume spike pattern: instead of counting logins per time window, it counts HIGH-impact news events. A burst of major events is a leading indicator that user logins will spike within 10–15 minutes.
+
+
+### Flow diagram
 ```mermaid
 flowchart TD
     subgraph sources["External Sources"]
@@ -23,8 +64,14 @@ flowchart TD
 
     subgraph egress["Storage and Egress"]
         db["news_events.db<br/>SQLite"]
-        log["financial_news.log<br/>Splunk"]
+        log["financial_news.log"]
         slack["Slack Webhook"]
+    end
+
+    predictor["core/predictor.py<br/>Volume Prediction"]
+
+    subgraph inference["Inference"]
+        narrative["core/classifier.py<br/>Narrative Summary"]
     end
 
     subgraph apifrontend["API and Frontend"]
@@ -37,19 +84,24 @@ flowchart TD
     YF --> market
 
     feeds --> classifier
-    market --> classifier
 
     classifier --> spike
     classifier --> db
     classifier --> log
+    market --> db
     spike --> slack
 
+    db --> predictor
+    db --> narrative
+    market --> predictor
+
+    predictor --> api
+    narrative --> api
     db --> api
     log --> api
     api --> ui
 ```
 
-The spike detection mirrors a login-volume spike pattern: instead of counting logins per time window, it counts HIGH-impact news events. A burst of major events is a leading indicator that user logins will spike within 10–15 minutes.
 
 
 ## News Article Classification levels
@@ -90,6 +142,44 @@ Each quote shows the current price and percentage change from the previous close
 | **MEDIUM volatility** | ≥ 1.0% move from previous close |
 
 Volatility signals are logged alongside news events, giving you a second leading indicator — a sharp pre-market move in European or Asian indices often precedes a US open-bell login surge even when no news article has been classified HIGH yet.
+
+## Volume Prediction
+
+The Dashboard displays a **Volume Prediction** banner at the top of the page — the primary output of Sentinel. It answers the question: *"How busy is our brokerage going to be in the next 15–30 minutes?"*
+
+### Prediction levels
+
+| Level | Label | Expected Login Volume | Action |
+|-------|-------|-----------------------|--------|
+| 1 | **NORMAL** | Baseline | No action needed |
+| 2 | **MODERATE** | 10–25% above baseline | Watch for escalation |
+| 3 | **ELEVATED** | 25–75% above baseline | Monitor closely — consider additional resources |
+| 4 | **SURGE** | 75%+ above baseline | All hands — expect significant login queue pressure |
+
+> Volume percentages are placeholders pending calibration against Splunk login data. Update the `LEVELS` dict in `core/predictor.py` once baseline correlation data is available.
+
+### How the score is computed
+
+A raw score (0–100+) is calculated by summing weighted signals, then mapped to a level. All signals are derived from data already collected by Sentinel — no additional sources required.
+
+| Signal | Condition | Points |
+|--------|-----------|--------|
+| Surge detector | Surge active | +40 |
+| HIGH news events | Per event in spike window (max 3) | +10 each |
+| MEDIUM news events | Per event in spike window (max 3) | +4 each |
+| Market volatility — HIGH | Per index ≥ 2% move (max 2) | +10 each |
+| Market volatility — MEDIUM | Per index ≥ 1% move (max 2) | +5 each |
+| Cross-market correlation | Global rally or sell-off signal | +10 |
+| Sentiment — fear | Overall sentiment score ≤ −0.5 | +8 |
+| Sentiment — euphoria | Overall sentiment score ≥ +0.5 | +5 |
+
+The banner also shows **key drivers** — the specific signals that contributed to the current score — so the prediction is always explainable, not just a number.
+
+The score is recomputed at most once per minute and cached in SQLite between requests.
+
+### Tuning
+
+Weights are defined in `core/predictor.py` (`W_*` constants) and can be adjusted without touching the API or frontend. The `actual_impact` column in `news_events` is reserved for recording whether a predicted spike was confirmed — once enough events are logged, weights can be calibrated empirically.
 
 ## Situation Summary
 
@@ -154,6 +244,7 @@ Additional settings (RSS feeds, market tickers, confidence thresholds) live in `
 The frontend is a Vue 3 SPA with three pages, accessible via the top navigation:
 
 ### Dashboard (`/`)
+- **Prediction banner** — color-coded brokerage login volume prediction (NORMAL / MODERATE / ELEVATED / SURGE) with expected volume range, recommended action, and key signal drivers; displayed at the very top of the page
 - **Surge alert banner** — prominently displayed when a SURGE is active
 - **Summary bar** — HIGH / MEDIUM / LOW counts for the last 24 hours; click tiles to toggle visibility
 - **Narrative summary** — AI-generated 3–4 sentence analysis of current events, updated every 15 minutes; surge-aware
@@ -162,7 +253,7 @@ The frontend is a Vue 3 SPA with three pages, accessible via the top navigation:
 
 ### Charts (`/charts`)
 - **Sentiment chart** — Time-series view of POSITIVE / NEGATIVE / NEUTRAL sentiment scores
-- **Global markets** — Live quotes for major indices (US, Europe, Asia) with % change, fetched via yfinance
+- **Global markets** — Live quotes for major indices (US, Europe, Asia) with % change, fetched via yfinance; per-symbol historical snapshots available via `/api/market/history` (not yet surfaced in the UI)
 
 ### Feeds (`/feeds`)
 - Add, remove, and enable/disable RSS feeds at runtime — no restart required

--- a/api/main.py
+++ b/api/main.py
@@ -17,6 +17,7 @@ from api.models import (
     TimeseriesResponse, SentimentTimeseriesResponse,
     FeedInfo, FeedValidationResult, AddFeedRequest, AddFeedResponse,
     MarketSnapshot, MarketVolatilitySignal, MarketDataResponse,
+    PredictionResponse,
 )
 from api.dependencies import get_db
 
@@ -144,6 +145,87 @@ def get_surge():
         window_minutes=config.SPIKE_WINDOW_MINUTES,
         threshold=config.SPIKE_HIGH_THRESHOLD,
     )
+
+
+PREDICTION_TTL_SECONDS = 60  # Recompute at most once per minute
+
+
+@router.get("/prediction", response_model=PredictionResponse)
+def get_prediction():
+    """Composite brokerage login volume prediction derived from news, market, and sentiment signals."""
+    from core import predictor, storage as cs
+
+    conn = get_db()
+
+    # Check cache — inputs change slowly, no need to recompute every request
+    cached_result  = cs.get_meta("prediction_result")
+    cached_at      = cs.get_meta("prediction_computed_at")
+    if cached_result and cached_at:
+        age = (datetime.now(timezone.utc) - datetime.fromisoformat(cached_at)).total_seconds()
+        if age < PREDICTION_TTL_SECONDS:
+            import json
+            data = json.loads(cached_result)
+            data["computed_at"] = cached_at
+            # tooltip is always derived from the level — never stored in cache
+            data["tooltip"] = predictor.LEVELS[data["level"]]["tooltip"]
+            return PredictionResponse(**data)
+
+    # --- Surge / HIGH count in window ---------------------------------------
+    cutoff = (datetime.now(timezone.utc) - timedelta(minutes=config.SPIKE_WINDOW_MINUTES)).isoformat()
+    row = conn.execute(
+        "SELECT COUNT(*) FROM news_events WHERE classification = 'HIGH' AND published_at >= ?",
+        (cutoff,),
+    ).fetchone()
+    high_count = row[0] if row else 0
+    surge_active = high_count >= config.SPIKE_HIGH_THRESHOLD
+
+    # --- MEDIUM count in window ---------------------------------------------
+    row = conn.execute(
+        "SELECT COUNT(*) FROM news_events WHERE classification = 'MEDIUM' AND published_at >= ?",
+        (cutoff,),
+    ).fetchone()
+    medium_count = row[0] if row else 0
+
+    # --- Overall sentiment score (last 24 h) --------------------------------
+    sentiment_score = 0.0
+    weights = {"HIGH": 3, "MEDIUM": 2, "LOW": 1}
+    sent_scores = {"POSITIVE": 1, "NEGATIVE": -1, "NEUTRAL": 0}
+    rows = conn.execute(
+        "SELECT classification, sentiment FROM news_events WHERE created_at >= datetime('now', '-24 hours')"
+    ).fetchall()
+    total_weight = sum(weights.get(r[0], 1) for r in rows)
+    if total_weight:
+        weighted_sum = sum(weights.get(r[0], 1) * sent_scores.get(r[1], 0) for r in rows)
+        sentiment_score = round(weighted_sum / total_weight, 3)
+
+    # --- Market volatility signals ------------------------------------------
+    market_signals = []
+    if config.MARKET_DATA_ENABLED:
+        try:
+            from core import market_data, storage as market_storage
+            snapshots = market_storage.get_latest_market_data()
+            if snapshots:
+                market_signals = market_data.detect_volatility(snapshots)
+        except Exception:
+            pass
+
+    # --- Compute score ------------------------------------------------------
+    result = predictor.compute_score(
+        surge_active=surge_active,
+        high_count_in_window=high_count,
+        medium_count_in_window=medium_count,
+        market_signals=market_signals,
+        sentiment_score=sentiment_score,
+    )
+
+    now_str = datetime.now(timezone.utc).isoformat()
+
+    # Cache result — tooltip is excluded (always derived from level at read time)
+    import json
+    cs.set_meta("prediction_result", json.dumps({k: v for k, v in result.items() if k != "tooltip"}))
+    cs.set_meta("prediction_computed_at", now_str)
+
+    return PredictionResponse(**result, computed_at=now_str)
 
 
 @router.get("/health", response_model=HealthResponse)

--- a/api/models.py
+++ b/api/models.py
@@ -125,6 +125,18 @@ class MarketDataResponse(BaseModel):
     market_data_enabled: bool
 
 
+class PredictionResponse(BaseModel):
+    level: int                # 1=NORMAL, 2=MODERATE, 3=ELEVATED, 4=SURGE
+    label: str                # NORMAL | MODERATE | ELEVATED | SURGE
+    color: str                # green | yellow | orange | red
+    volume: str               # expected login volume description
+    action: str               # recommended action
+    tooltip: str              # detailed action guidance (shown on hover)
+    score: int                # raw composite score
+    drivers: list[str]        # plain-English explanation of top contributors
+    computed_at: str          # ISO timestamp
+
+
 class AddFeedRequest(BaseModel):
     """Request to add a new feed."""
     url: str

--- a/core/predictor.py
+++ b/core/predictor.py
@@ -1,0 +1,186 @@
+"""
+Brokerage login volume predictor.
+
+Combines news classification, market volatility, surge state, and sentiment
+into a single composite score, then maps it to a labelled prediction level.
+
+This is a pure function module — no I/O, no DB access.  All inputs are
+passed in so the logic is easy to unit-test and the weights easy to tune.
+
+Scoring weights (starting values — tune empirically using actual_impact data):
+
+  News signals (30-min window)
+    Surge active                        +40
+    Each HIGH event  (max 3, i.e. +30)  +10 each
+    Each MEDIUM event (max 3, i.e. +12) +4  each
+
+  Market signals
+    HIGH-severity volatility signal      +10 each (max 2, i.e. +20)
+    MEDIUM-severity volatility signal    +5  each (max 2, i.e. +10)
+    Cross-market correlation signal      +10 (counts once regardless of count)
+
+  Sentiment
+    overall_sentiment_score <= -0.5      +8   (fear / panic selling)
+    overall_sentiment_score >=  0.5      +5   (euphoria / FOMO buying)
+
+Level thresholds
+    >= 60  →  SURGE    (level 4)
+    >= 35  →  ELEVATED (level 3)
+    >= 15  →  MODERATE (level 2)
+    <  15  →  NORMAL   (level 1)
+"""
+
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Weights — adjust here to tune the model
+# ---------------------------------------------------------------------------
+W_SURGE_ACTIVE      = 40
+W_HIGH_EVENT        = 10
+W_HIGH_EVENT_MAX    = 3   # cap on number of HIGH events scored
+W_MEDIUM_EVENT      = 4
+W_MEDIUM_EVENT_MAX  = 3
+W_MARKET_HIGH       = 10
+W_MARKET_HIGH_MAX   = 2
+W_MARKET_MEDIUM     = 5
+W_MARKET_MEDIUM_MAX = 2
+W_CROSS_MARKET      = 10  # added once if any cross-market signal present
+W_SENTIMENT_FEAR    = 8   # score <= -0.5
+W_SENTIMENT_EUPHORIA= 5   # score >= +0.5
+
+# Level thresholds
+LEVEL_SURGE    = 60
+LEVEL_ELEVATED = 35
+LEVEL_MODERATE = 15
+
+LEVELS = {
+    4: {
+        "label": "SURGE", "color": "red", "volume": "75%+ above baseline",
+        "action": "All hands — expect significant login queue pressure",
+        "tooltip": "Activate incident response. Login queues may be forming. Notify infrastructure and support teams immediately. Reassess every 5 minutes.",
+    },
+    3: {
+        "label": "ELEVATED", "color": "orange", "volume": "25–75% above baseline",
+        "action": "Monitor closely — consider additional resources",
+        "tooltip": "Alert on-call team and review capacity. Volumes are significantly above baseline and may continue to rise. Reassess every 10 minutes.",
+    },
+    2: {
+        "label": "MODERATE", "color": "yellow", "volume": "10–25% above baseline",
+        "action": "Watch for escalation",
+        "tooltip": "No intervention required yet. Volumes are running slightly above baseline. Monitor for additional HIGH events or market signals that could push this to ELEVATED.",
+    },
+    1: {
+        "label": "NORMAL", "color": "green", "volume": "Baseline",
+        "action": "No action needed",
+        "tooltip": "Login volumes are within expected baseline range. Continue normal monitoring.",
+    },
+}
+
+
+def compute_score(
+    surge_active: bool,
+    high_count_in_window: int,
+    medium_count_in_window: int,
+    market_signals: Optional[list] = None,
+    sentiment_score: float = 0.0,
+) -> dict:
+    """
+    Compute the volume prediction score and return a result dict.
+
+    Parameters
+    ----------
+    surge_active : bool
+        Whether the spike detector has fired a SURGE.
+    high_count_in_window : int
+        Number of HIGH-classified events in the current spike window.
+    medium_count_in_window : int
+        Number of MEDIUM-classified events in the current spike window.
+    market_signals : list of dicts, optional
+        Volatility signal dicts from market_data.detect_volatility().
+        Each dict must have at least ``severity`` (HIGH|MEDIUM) and
+        ``type`` (index_move|cross_market_correlation) keys.
+    sentiment_score : float
+        Overall weighted sentiment score in [-1.0, 1.0] from /events/summary.
+
+    Returns
+    -------
+    dict with keys:
+        level       int   1–4
+        label       str   NORMAL / MODERATE / ELEVATED / SURGE
+        color       str   green / yellow / orange / red
+        score       int   raw composite score (0–100+)
+        drivers     list  plain-English strings explaining top contributors
+    """
+    if market_signals is None:
+        market_signals = []
+
+    score = 0
+    drivers = []
+
+    # --- Surge active -------------------------------------------------------
+    if surge_active:
+        score += W_SURGE_ACTIVE
+        drivers.append("Surge active")
+
+    # --- HIGH events --------------------------------------------------------
+    capped_high = min(high_count_in_window, W_HIGH_EVENT_MAX)
+    if capped_high:
+        score += capped_high * W_HIGH_EVENT
+        drivers.append(f"{capped_high} HIGH event{'s' if capped_high > 1 else ''} in window")
+
+    # --- MEDIUM events ------------------------------------------------------
+    capped_med = min(medium_count_in_window, W_MEDIUM_EVENT_MAX)
+    if capped_med:
+        score += capped_med * W_MEDIUM_EVENT
+        drivers.append(f"{capped_med} MEDIUM event{'s' if capped_med > 1 else ''} in window")
+
+    # --- Market volatility signals ------------------------------------------
+    high_mkt   = [s for s in market_signals if s.get("severity") == "HIGH"   and s.get("type") == "index_move"]
+    medium_mkt = [s for s in market_signals if s.get("severity") == "MEDIUM" and s.get("type") == "index_move"]
+    cross      = [s for s in market_signals if s.get("type") == "cross_market_correlation"]
+
+    capped_high_mkt = min(len(high_mkt), W_MARKET_HIGH_MAX)
+    if capped_high_mkt:
+        score += capped_high_mkt * W_MARKET_HIGH
+        names = ", ".join(s.get("name", s.get("symbol", "?")) for s in high_mkt[:capped_high_mkt])
+        drivers.append(f"High market volatility: {names}")
+
+    capped_med_mkt = min(len(medium_mkt), W_MARKET_MEDIUM_MAX)
+    if capped_med_mkt:
+        score += capped_med_mkt * W_MARKET_MEDIUM
+        names = ", ".join(s.get("name", s.get("symbol", "?")) for s in medium_mkt[:capped_med_mkt])
+        drivers.append(f"Moderate market volatility: {names}")
+
+    if cross:
+        score += W_CROSS_MARKET
+        drivers.append(cross[0].get("message", "Cross-market correlation signal"))
+
+    # --- Sentiment ----------------------------------------------------------
+    if sentiment_score <= -0.5:
+        score += W_SENTIMENT_FEAR
+        drivers.append("Negative sentiment (fear / selling pressure)")
+    elif sentiment_score >= 0.5:
+        score += W_SENTIMENT_EUPHORIA
+        drivers.append("Positive sentiment (euphoria / buying pressure)")
+
+    # --- Map to level -------------------------------------------------------
+    if score >= LEVEL_SURGE:
+        level = 4
+    elif score >= LEVEL_ELEVATED:
+        level = 3
+    elif score >= LEVEL_MODERATE:
+        level = 2
+    else:
+        level = 1
+
+    return {
+        "level": level,
+        "label": LEVELS[level]["label"],
+        "color": LEVELS[level]["color"],
+        "volume": LEVELS[level]["volume"],
+        "action": LEVELS[level]["action"],
+        "tooltip": LEVELS[level]["tooltip"],
+        "score": score,
+        "drivers": drivers,
+    }

--- a/frontend/src/components/PredictionBanner.vue
+++ b/frontend/src/components/PredictionBanner.vue
@@ -1,0 +1,120 @@
+<script setup>
+defineProps({ prediction: Object })
+
+const AGO_INTERVAL = 10_000 // update "X seconds ago" every 10s
+
+import { ref, onMounted, onUnmounted } from 'vue'
+const secondsAgo = ref(0)
+let timer
+
+onMounted(() => {
+  timer = setInterval(() => { secondsAgo.value += 10 }, AGO_INTERVAL)
+})
+onUnmounted(() => clearInterval(timer))
+
+// Reset counter whenever the parent updates the prediction prop
+import { watch } from 'vue'
+watch(() => props?.prediction?.computed_at, () => { secondsAgo.value = 0 })
+</script>
+
+<template>
+  <div v-if="prediction" class="prediction-banner" :data-level="prediction.label">
+    <div class="prediction-left">
+      <span class="prediction-label">{{ prediction.label }}</span>
+      <span class="prediction-sublabel">{{ prediction.volume }}</span>
+    </div>
+
+    <div class="prediction-action">{{ prediction.action }} <span class="tooltip-icon" :title="prediction.tooltip">ⓘ</span></div>
+
+    <div class="prediction-drivers" v-if="prediction.drivers?.length">
+      <span v-for="(d, i) in prediction.drivers" :key="i" class="driver-chip">{{ d }}</span>
+    </div>
+
+    <div class="prediction-meta">
+      score {{ prediction.score }}
+      <span v-if="secondsAgo > 0"> &middot; updated {{ secondsAgo }}s ago</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.prediction-banner {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 14px 20px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+/* Level colours */
+.prediction-banner[data-level="NORMAL"]   { background: #1a3a1a; border-left: 5px solid #4caf50; }
+.prediction-banner[data-level="MODERATE"] { background: #3a3000; border-left: 5px solid #ffc107; }
+.prediction-banner[data-level="ELEVATED"] { background: #3a1800; border-left: 5px solid #ff9800; }
+.prediction-banner[data-level="SURGE"]    { background: #3a0000; border-left: 5px solid #f44336; }
+
+.prediction-left {
+  display: flex;
+  flex-direction: column;
+  min-width: 130px;
+}
+
+.prediction-label {
+  font-size: 1.4rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  line-height: 1;
+}
+
+.prediction-banner[data-level="NORMAL"]   .prediction-label { color: #4caf50; }
+.prediction-banner[data-level="MODERATE"] .prediction-label { color: #ffc107; }
+.prediction-banner[data-level="ELEVATED"] .prediction-label { color: #ff9800; }
+.prediction-banner[data-level="SURGE"]    .prediction-label { color: #f44336; }
+
+.prediction-sublabel {
+  font-size: 0.7rem;
+  color: #888;
+  margin-top: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.prediction-action {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #ddd;
+  white-space: nowrap;
+  padding: 0 16px;
+  border-left: 1px solid rgba(255,255,255,0.15);
+  border-right: 1px solid rgba(255,255,255,0.15);
+}
+
+.prediction-drivers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex: 1;
+}
+
+.driver-chip {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 4px;
+  padding: 3px 9px;
+  font-size: 0.78rem;
+  color: #ccc;
+  white-space: nowrap;
+}
+
+.tooltip-icon {
+  cursor: help;
+}
+
+.prediction-meta {
+  font-size: 0.72rem;
+  color: #666;
+  white-space: nowrap;
+  align-self: flex-end;
+}
+</style>

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed, provide, onMounted, onUnmounted, watch } from 'vue'
+import PredictionBanner  from '../components/PredictionBanner.vue'
 import SurgeAlert        from '../components/SurgeAlert.vue'
 import SummaryBar        from '../components/SummaryBar.vue'
 import NarrativeSummary  from '../components/NarrativeSummary.vue'
@@ -11,6 +12,7 @@ const events      = ref([])
 const summary     = ref({ counts: [], total: 0, overall_sentiment: null, overall_sentiment_score: 0 })
 const surge       = ref({ surge_active: false, high_count_in_window: 0, window_minutes: 30 })
 const narrative   = ref({ text: '', generated_at: null, surge_active: false })
+const prediction  = ref(null)
 const timeseries          = ref({ labels: [], high: [], medium: [], low: [] })
 const sentimentTimeseries = ref({ labels: [], scores: [] })
 const lastRefresh = ref(null)
@@ -38,21 +40,28 @@ function setFilter(cls) {
 }
 
 async function refresh() {
+  // Fetch narrative separately — it may block on Ollama inference.
+  // All other endpoints are fast and update the UI immediately.
+  fetch('/api/events/narrative')
+    .then(r => r.json())
+    .then(data => { narrative.value = data })
+    .catch(e => console.error('Narrative fetch failed:', e))
+
   try {
-    const [evRes, sumRes, surRes, narRes, tsRes, stRes] = await Promise.all([
+    const [evRes, sumRes, surRes, tsRes, stRes, predRes] = await Promise.all([
       fetch('/api/events?limit=200'),
       fetch(`/api/events/summary?hours=${selectedHours.value}`),
       fetch('/api/surge'),
-      fetch('/api/events/narrative'),
       fetch(`/api/events/timeseries?hours=${selectedHours.value}`),
       fetch(`/api/events/sentiment-timeseries?hours=${selectedHours.value}`),
+      fetch('/api/prediction'),
     ])
-    events.value             = await evRes.json()
-    summary.value            = await sumRes.json()
-    surge.value              = await surRes.json()
-    narrative.value          = await narRes.json()
-    timeseries.value         = await tsRes.json()
+    events.value              = await evRes.json()
+    summary.value             = await sumRes.json()
+    surge.value               = await surRes.json()
+    timeseries.value          = await tsRes.json()
     sentimentTimeseries.value = await stRes.json()
+    prediction.value          = await predRes.json()
     lastRefresh.value = new Date().toLocaleTimeString('en-US', { timeZone: timezone.value, hour: '2-digit', minute: '2-digit' }) + ' ET'
   } catch (e) {
     console.error('Refresh failed:', e)
@@ -80,6 +89,7 @@ watch(selectedHours, refresh)
       last updated {{ lastRefresh }}
     </span>
   </h1>
+  <PredictionBanner  :prediction="prediction" />
   <SurgeAlert        :surge="surge" />
   <TimeRangeSelector v-model="selectedHours" />
   <SummaryBar        :summary="summary" :hidden-classes="hiddenClasses" :timeseries="timeseries" :sentiment-timeseries="sentimentTimeseries" :hours="selectedHours" @filter="setFilter" />


### PR DESCRIPTION
## Summary

- Adds a **Volume Prediction** banner at the top of the Dashboard — the primary output of Sentinel — showing NORMAL / MODERATE / ELEVATED / SURGE with expected login volume range, recommended action, and key signal drivers
- Prediction is computed from a weighted scoring engine combining surge state, HIGH/MEDIUM event counts in the spike window, market volatility signals, and overall sentiment score
- Each level includes a hover tooltip with detailed guidance
- Narrative fetch decoupled from the main `Promise.all` so the banner and all fast endpoints render immediately without waiting for Ollama
- README updated with Volume Prediction section, scoring table, and updated flow diagram

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)