### PR TITLE
feat: move Global Markets below Prediction banner on Dashboard

### DIFF
--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -90,10 +90,10 @@ watch(selectedHours, refresh)
     </span>
   </h1>
   <PredictionBanner  :prediction="prediction" />
+  <GlobalMarkets />
   <SurgeAlert        :surge="surge" />
   <TimeRangeSelector v-model="selectedHours" />
   <SummaryBar        :summary="summary" :hidden-classes="hiddenClasses" :timeseries="timeseries" :sentiment-timeseries="sentimentTimeseries" :hours="selectedHours" @filter="setFilter" />
   <NarrativeSummary  :narrative="narrative" />
-  <GlobalMarkets />
   <EventFeed         :events="filteredEvents" :hidden-classes="hiddenClasses" />
 </template>


### PR DESCRIPTION
## Summary

- Moves `GlobalMarkets` component to directly below `PredictionBanner` on the Dashboard
- Market data is a direct input to the prediction score — placing it alongside the prediction makes the supporting context immediately visible without navigating to Charts

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)