### PR TITLE
feat: add title and tooltip to News Event Counts summary bar

### DIFF
--- a/frontend/src/components/SummaryBar.vue
+++ b/frontend/src/components/SummaryBar.vue
@@ -54,6 +54,10 @@ function formatTimeWindow() {
 </script>
 
 <template>
+  <div class="summary-bar-header">
+    <span class="summary-bar-title">News Event Counts</span>
+    <span class="summary-bar-info" title="Each article is classified by its likely impact on brokerage login volume (HIGH / MEDIUM / LOW) and assigned a financial sentiment (▲ Positive / ▼ Negative / ~ Neutral). HIGH events are weighted 3×, MEDIUM 2×, LOW 1× in the overall sentiment score. Click a tile to filter the event feed below.">ⓘ</span>
+  </div>
   <div class="summary-bar">
     <div
       v-for="cls in ['HIGH', 'MEDIUM', 'LOW']"
@@ -149,6 +153,27 @@ function formatTimeWindow() {
 </template>
 
 <style scoped>
+.summary-bar-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 20px;
+  margin-top: 16px;
+  margin-bottom: 6px;
+}
+.summary-bar-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #888;
+}
+.summary-bar-info {
+  font-size: 0.78rem;
+  color: #555;
+  cursor: help;
+}
+
 .summary-bar { display: flex; gap: 12px; align-items: stretch;
                padding: 16px 20px; border-bottom: 1px solid #1e1e1e;
                overflow-x: auto; -webkit-overflow-scrolling: touch;

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -92,8 +92,20 @@ watch(selectedHours, refresh)
   <PredictionBanner  :prediction="prediction" />
   <GlobalMarkets />
   <SurgeAlert        :surge="surge" />
+  <h2 class="section-header">News Analysis</h2>
   <TimeRangeSelector v-model="selectedHours" />
   <SummaryBar        :summary="summary" :hidden-classes="hiddenClasses" :timeseries="timeseries" :sentiment-timeseries="sentimentTimeseries" :hours="selectedHours" @filter="setFilter" />
   <NarrativeSummary  :narrative="narrative" />
   <EventFeed         :events="filteredEvents" :hidden-classes="hiddenClasses" />
 </template>
+
+<style scoped>
+.section-header {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #888;
+  margin: 24px 0 12px;
+}
+</style>


### PR DESCRIPTION
## Summary

- Adds "News Event Counts" section header above the SummaryBar in the same style as the Global Markets title
- Adds ⓘ tooltip explaining HIGH/MEDIUM/LOW classification, ▲▼~ sentiment indicators, classification weighting (HIGH×3, MEDIUM×2, LOW×1), and click-to-filter behaviour
- Adds "News Analysis" section header above the TimeRangeSelector on the Dashboard

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)