### PR TITLE
feat: add read-only mode for feed management

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -324,7 +324,7 @@ def get_sentiment_timeseries(hours: int = Query(24, ge=1, le=720)):
 @router.get("/config", response_model=ConfigResponse)
 def get_config():
     """Frontend display settings derived from server config."""
-    return ConfigResponse(display_timezone=config.DISPLAY_TIMEZONE)
+    return ConfigResponse(display_timezone=config.DISPLAY_TIMEZONE, read_only=config.READ_ONLY)
 
 
 NARRATIVE_TTL_SECONDS = 900  # Regenerate at most every 15 minutes
@@ -415,6 +415,11 @@ def list_feeds():
     ]
 
 
+def _check_read_only():
+    if config.READ_ONLY:
+        raise HTTPException(status_code=403, detail="This instance is in read-only mode.")
+
+
 @router.post("/feeds/validate", response_model=FeedValidationResult)
 def validate_feed(request: AddFeedRequest):
     """Test a feed URL and detect its type.
@@ -443,6 +448,7 @@ def validate_feed(request: AddFeedRequest):
 @router.post("/feeds", response_model=AddFeedResponse)
 def add_feed(request: AddFeedRequest):
     """Add a new RSS feed after validating it."""
+    _check_read_only()
     from core import feed_handlers, feeds_manager
 
     # Validate the feed first
@@ -483,6 +489,7 @@ def add_feed(request: AddFeedRequest):
 @router.delete("/feeds/{feed_id}")
 def delete_feed(feed_id: str):
     """Remove a feed by ID."""
+    _check_read_only()
     from core import feeds_manager
 
     success = feeds_manager.delete_feed(feed_id)
@@ -495,6 +502,7 @@ def delete_feed(feed_id: str):
 @router.patch("/feeds/{feed_id}")
 def toggle_feed(feed_id: str, active: bool = Query(..., description="Enable or disable feed")):
     """Enable/disable a feed."""
+    _check_read_only()
     from core import feeds_manager
 
     feed = feeds_manager.toggle_feed(feed_id, active)

--- a/api/models.py
+++ b/api/models.py
@@ -61,6 +61,7 @@ class NarrativeResponse(BaseModel):
 
 class ConfigResponse(BaseModel):
     display_timezone: str
+    read_only: bool
 
 
 class TimeseriesResponse(BaseModel):

--- a/core/config.py
+++ b/core/config.py
@@ -74,5 +74,8 @@ DISPLAY_TIMEZONE = os.getenv("DISPLAY_TIMEZONE", "").strip() or "America/New_Yor
 DB_PATH  = os.getenv("SENTINEL_DB_PATH",  str(_ROOT / "news_events.db"))
 LOG_PATH = os.getenv("SENTINEL_LOG_PATH", str(_ROOT / "financial_news.log"))
 
+# Read-only mode — disables feed add/delete/toggle via API and UI
+READ_ONLY = os.getenv("READ_ONLY", "true").strip().lower() not in ("0", "false", "no")
+
 # Alerts — Slack (set webhook URL to enable, leave None to disable)
 SLACK_WEBHOOK_URL = None      # e.g. "https://hooks.slack.com/services/..."

--- a/frontend/src/components/FeedManager.vue
+++ b/frontend/src/components/FeedManager.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { ref, computed } from 'vue'
 
+const props = defineProps({ readOnly: { type: Boolean, default: false } })
+
 const feeds = ref([])
 const loading = ref(false)
 const newFeedUrl = ref('')
@@ -132,7 +134,8 @@ const hasErrors = computed(() => validationResult.value?.errors?.length > 0)
   <div class="feed-manager">
     <div class="header">
       <h2>RSS Feed Management</h2>
-      <button v-if="!showAddForm" class="btn-add" @click="showAddForm = true">
+      <span v-if="readOnly" class="read-only-badge" title="This instance is in read-only mode. Feed management is disabled.">Read-only</span>
+      <button v-if="!showAddForm && !readOnly" class="btn-add" @click="showAddForm = true">
         + Add Feed
       </button>
     </div>
@@ -253,12 +256,17 @@ const hasErrors = computed(() => validationResult.value?.errors?.length > 0)
           </div>
           <div class="feed-actions">
             <button
-              @click="toggleFeed(feed.id, feed.active)"
-              :class="['btn-toggle', feed.active ? 'active' : 'inactive']"
+              @click="!readOnly && toggleFeed(feed.id, feed.active)"
+              :class="['btn-toggle', feed.active ? 'active' : 'inactive', { disabled: readOnly }]"
+              :title="readOnly ? 'Read-only mode' : ''"
             >
               {{ feed.active ? '✓ Active' : '○ Inactive' }}
             </button>
-            <button @click="deleteFeed(feed.id)" class="btn-delete">
+            <button
+              v-if="!readOnly"
+              @click="deleteFeed(feed.id)"
+              class="btn-delete"
+            >
               Delete
             </button>
           </div>
@@ -295,6 +303,24 @@ const hasErrors = computed(() => validationResult.value?.errors?.length > 0)
   font-size: 1.5rem;
   color: #e0e0e0;
   margin: 0;
+}
+
+.read-only-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #888;
+  background: #222;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 4px 10px;
+  cursor: default;
+}
+
+.btn-toggle.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .btn-add {

--- a/frontend/src/pages/FeedsPage.vue
+++ b/frontend/src/pages/FeedsPage.vue
@@ -1,10 +1,21 @@
 <script setup>
+import { ref, onMounted } from 'vue'
 import FeedManager from '../components/FeedManager.vue'
+
+const readOnly = ref(false)
+
+onMounted(async () => {
+  const res = await fetch('/api/config').catch(() => null)
+  if (res?.ok) {
+    const cfg = await res.json()
+    readOnly.value = cfg.read_only ?? false
+  }
+})
 </script>
 
 <template>
   <div class="feeds-page">
-    <FeedManager />
+    <FeedManager :read-only="readOnly" />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary

- Adds `READ_ONLY` env var (default `true`) to lock down feed management for shared/prototype deployments
- Server-side: write endpoints (`POST /feeds`, `DELETE /feeds/{id}`, `PATCH /feeds/{id}`) return `403` when read-only
- Frontend: read-only badge replaces Add Feed button, toggle buttons are dimmed and non-functional, Delete buttons hidden
- Set `READ_ONLY=false` in `.env` to re-enable feed management

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)