### PR TITLE
fix: prevent sticky zoom state on mobile browsers

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Sentinel — Financial News Monitor</title>
     <style>


### PR DESCRIPTION
## Summary

Adds `maximum-scale=1.0` to the viewport meta tag to prevent the layout getting stuck in a zoomed state after pinch-zooming on mobile.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)