### PR TITLE
fix: resolve SQLite database locking in production

### DIFF
--- a/core/storage.py
+++ b/core/storage.py
@@ -73,7 +73,11 @@ _conn: sqlite3.Connection | None = None
 def _get_conn() -> sqlite3.Connection:
     global _conn
     if _conn is None:
-        _conn = sqlite3.connect(config.DB_PATH, check_same_thread=False)
+        _conn = sqlite3.connect(config.DB_PATH, check_same_thread=False, timeout=10.0)
+        # Enable WAL mode for better concurrency (reader/writer can coexist)
+        _conn.execute("PRAGMA journal_mode=WAL")
+        # Optimize for faster writes
+        _conn.execute("PRAGMA synchronous=NORMAL")
         _conn.executescript(_SCHEMA)
         # Migrate existing databases that predate the sentiment column
         try:

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -16,7 +16,7 @@ services:
 
   api:
     image: ghcr.io/kilgorjn/sentinel:latest
-    command: uvicorn api.main:app --host 0.0.0.0 --port 8000
+    command: uvicorn api.main:app --host 0.0.0.0 --port 8000 --workers 1
     ports:
       - "${API_PORT:-8000}:8000"
     volumes:


### PR DESCRIPTION
## Summary
Fixes production crashes caused by SQLite database locking when monitor.py writes concurrently with API requests.

## Changes
- **core/storage.py**: Enable WAL mode for better concurrency, add 10-second timeout, optimize synchronous pragma
- **docker-compose.portainer.yml**: Configure single uvicorn worker to eliminate inter-process lock contention

## Root Cause
Monitor and API were competing for exclusive locks on SQLite database. Multiple uvicorn workers + continuous writes from monitor.py caused deadlocks.

## Testing
After deployment, verify:
- Monitor loop runs without database locked errors
- API responds normally under load
- No SQLite lock-related exceptions in logs

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)