### PR TITLE
fix: API use shared database connection with WAL configuration

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,14 +1,15 @@
 """Shared SQLite connection for FastAPI route handlers."""
 
 import sqlite3
-from core import config
-
-_conn: sqlite3.Connection | None = None
+from core import storage
 
 
 def get_db() -> sqlite3.Connection:
-    global _conn
-    if _conn is None:
-        _conn = sqlite3.connect(config.DB_PATH, check_same_thread=False)
-        _conn.row_factory = sqlite3.Row
-    return _conn
+    """Get the properly configured database connection from storage.
+
+    This ensures the API uses the same connection with WAL mode,
+    timeout settings, and synchronous pragmas as the monitor.
+    """
+    conn = storage._get_conn()
+    conn.row_factory = sqlite3.Row
+    return conn


### PR DESCRIPTION
## Summary
Fixes critical bug where the API bypassed WAL configuration by using a separate database connection.

## Problem
Two separate global connections were created:
- **storage.py._get_conn()** → WAL mode, 10s timeout, optimized pragmas
- **api/dependencies.py.get_db()** → No WAL, no timeout, default settings

The API routes used get_db(), so they never benefited from the WAL fix.

## Solution
Make api/dependencies.py reuse storage._get_conn() so all database access uses the properly configured connection.

## Testing
After deployment:
- Monitor and API both use same WAL-enabled connection
- No more "database is locked" errors
- Concurrent requests from API + writes from monitor should coexist cleanly

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)