### PR TITLE
fix: skip existing meta keys during SQLite migration

### DIFF
--- a/core/migrations.py
+++ b/core/migrations.py
@@ -140,8 +140,14 @@ def migrate_from_sqlite() -> bool:
         log.info("Migrating meta...")
         rows = sqlite_conn.execute("SELECT * FROM meta").fetchall()
         migrated = skipped = 0
+        # Pre-fetch existing keys so we don't collide with rows the API already wrote
+        existing_meta_keys = {r.key for r in session.query(Meta).all()}
         for row in rows:
             if row["key"] == MIGRATION_FLAG:
+                continue
+            if row["key"] in existing_meta_keys:
+                log.debug("Skipping already-present meta key: %s", row["key"])
+                skipped += 1
                 continue
             try:
                 session.add(Meta(key=row["key"], value=row["value"]))


### PR DESCRIPTION
## Summary
- The API writes meta keys (`narrative_*`, `prediction_*`) on startup before the monitor runs its SQLite migration
- When the migration then tries to INSERT those same keys, MySQL throws a duplicate primary key error and rolls back the entire migration transaction — crashing the monitor on every restart
- Pre-fetch existing meta keys at the start of the meta migration step and skip any that are already present

## Root cause
Found in production: monitor crash-looped with `IntegrityError: (1062, "Duplicate entry 'narrative_generated_at' for key 'meta.PRIMARY'")`

## Test plan
- [ ] Deploy updated image to prod
- [ ] Confirm monitor starts without crash
- [ ] Confirm `sqlite_migration_completed` flag appears in meta table after startup
- [ ] Confirm news_events and feeds are populated from SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)