### PR TITLE
feat: decouple feed fetching from classification using raw_articles table

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -2,7 +2,7 @@
 
 import os
 from datetime import datetime, timezone
-from sqlalchemy import create_engine, Column, Integer, String, Float, Boolean, DateTime, Index
+from sqlalchemy import create_engine, Column, Integer, String, Float, Boolean, DateTime, Index, Text
 from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.pool import QueuePool
 
@@ -26,6 +26,36 @@ engine = create_engine(
 SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
 
 Base = declarative_base()
+
+
+class RawArticle(Base):
+    """Raw fetched article, persisted before classification."""
+    __tablename__ = "raw_articles"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    title_hash = Column(String(64), unique=True, nullable=False)  # SHA256 of normalized title — dedup key
+    title = Column(String(500), nullable=False)
+    source = Column(String(100))
+    url = Column(String(1000))
+    summary = Column(Text)
+    published_at = Column(DateTime)
+    fetched_at = Column(DateTime, nullable=False)
+
+    __table_args__ = (
+        Index("idx_raw_fetched_at", "fetched_at"),
+        Index("idx_raw_published_at", "published_at"),
+    )
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "title": self.title,
+            "source": self.source,
+            "url": self.url,
+            "summary": self.summary,
+            "published_at": self.published_at.isoformat() if self.published_at else None,
+            "fetched_at": self.fetched_at.isoformat() if self.fetched_at else None,
+        }
 
 
 class NewsEvent(Base):

--- a/core/db.py
+++ b/core/db.py
@@ -47,14 +47,20 @@ class RawArticle(Base):
     )
 
     def to_dict(self):
+        """Return a dict for internal pipeline use.
+
+        published_at and fetched_at are returned as datetime objects (not ISO
+        strings) so downstream code (classifier, spike detector, save_event)
+        can use them directly without reparsing.
+        """
         return {
             "id": self.id,
             "title": self.title,
             "source": self.source,
             "url": self.url,
             "summary": self.summary,
-            "published_at": self.published_at.isoformat() if self.published_at else None,
-            "fetched_at": self.fetched_at.isoformat() if self.fetched_at else None,
+            "published_at": self.published_at,
+            "fetched_at": self.fetched_at,
         }
 
 

--- a/core/feeds.py
+++ b/core/feeds.py
@@ -128,15 +128,17 @@ def fetch_newsapi() -> list[dict]:
         return []
 
 
-def fetch_all() -> list[dict]:
-    """Fetch from all sources, deduplicate, filter stale, return sorted newest-first."""
+def fetch_all() -> int:
+    """Fetch from all sources, filter stale, persist to raw_articles. Returns count saved.
+
+    Deduplication is handled at the database level via the title_hash UNIQUE constraint
+    in raw_articles — no need to track seen hashes in memory across poll cycles.
+    """
     articles = fetch_rss() + fetch_newsapi()
 
     cutoff = datetime.now(timezone.utc) - timedelta(hours=config.MAX_ARTICLE_AGE_HOURS)
 
-    # Deduplicate by normalized title fingerprint and drop articles older than MAX_ARTICLE_AGE_HOURS
-    seen: set[str] = set()
-    unique = []
+    fresh = []
     stale = 0
     for a in articles:
         if not a["title"]:
@@ -144,12 +146,11 @@ def fetch_all() -> list[dict]:
         if a["published_at"] < cutoff:
             stale += 1
             continue
-        key = _normalize_title(a["title"])
-        fp = hashlib.md5(key.encode()).hexdigest()
-        if fp not in seen:
-            seen.add(fp)
-            unique.append(a)
+        fresh.append(a)
 
-    unique.sort(key=lambda x: x["published_at"], reverse=True)
-    log.info("Fetched %d unique articles from %d total (%d stale discarded)", len(unique), len(articles), stale)
-    return unique
+    saved = storage.save_raw_articles(fresh)
+    log.info(
+        "Fetched %d articles from %d total (%d stale discarded, %d new saved to raw_articles)",
+        len(fresh), len(articles), stale, saved,
+    )
+    return saved

--- a/core/feeds.py
+++ b/core/feeds.py
@@ -1,7 +1,5 @@
 """Fetch and parse financial news from RSS feeds and optionally NewsAPI."""
 
-import re
-import hashlib
 import logging
 from datetime import datetime, timedelta, timezone
 
@@ -11,11 +9,6 @@ import requests
 from . import config, storage
 
 log = logging.getLogger(__name__)
-
-
-def _normalize_title(title: str) -> str:
-    """Lowercase + strip punctuation for deduplication."""
-    return re.sub(r"[^a-z0-9 ]", "", title.lower()).strip()
 
 
 def _parse_time(entry) -> datetime:

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -76,13 +76,14 @@ def _is_market_hours() -> bool:
 
 
 def classify_pending(detector: spike_detector.SpikeDetector) -> int:
-    """Classify all raw articles not yet processed by the monitor.
+    """Classify one batch of up to 50 unprocessed raw articles.
 
     Reads from raw_articles using a cursor stored in meta, classifies each
     article via Ollama, writes results to news_events, and advances the cursor
     after each successful classification so a mid-batch crash is recoverable.
+    Call repeatedly each poll cycle to drain a backlog.
 
-    Returns the number of articles classified.
+    Returns the number of articles classified in this batch.
     """
     articles = storage.get_unclassified_articles(batch_size=50)
     if not articles:

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -75,26 +75,45 @@ def _is_market_hours() -> bool:
     return 9 <= now_et.hour < 17
 
 
-def process_articles(article_list: list[dict], detector: spike_detector.SpikeDetector) -> None:
-    """Classify each article, store it, alert if needed, update spike detector."""
-    for article in article_list:
+def classify_pending(detector: spike_detector.SpikeDetector) -> int:
+    """Classify all raw articles not yet processed by the monitor.
+
+    Reads from raw_articles using a cursor stored in meta, classifies each
+    article via Ollama, writes results to news_events, and advances the cursor
+    after each successful classification so a mid-batch crash is recoverable.
+
+    Returns the number of articles classified.
+    """
+    articles = storage.get_unclassified_articles(batch_size=50)
+    if not articles:
+        return 0
+
+    classified = 0
+    for article in articles:
         title = article.get("title", "")
 
-        # Skip if we've already logged this title in the past 24 hours
+        # Skip if already in news_events (safety net for cursor resets)
         if storage.already_seen(title):
             log.debug("Skipping already-seen: %s", title)
+            storage.advance_cursor(article["id"])
             continue
 
         result = classifier.classify(article)
         level  = result.get("classification", "LOW")
 
-        # Print to console
         alerts.alert_article(article, result)
+        saved = storage.save_event(article, result)
 
-        # Persist
-        storage.save_event(article, result)
+        if not saved:
+            # DB write failed — leave cursor here so this article is retried next cycle
+            log.error("Skipping cursor advance for article id=%s due to save failure", article["id"])
+            continue
 
-        # Check for surge
+        # Advance cursor immediately — if we crash on the next article,
+        # this one won't be reprocessed
+        storage.advance_cursor(article["id"])
+        classified += 1
+
         is_new_surge = detector.record(article, level)
         if is_new_surge:
             alerts.alert_surge(
@@ -106,6 +125,8 @@ def process_articles(article_list: list[dict], detector: spike_detector.SpikeDet
         # Small gap between Ollama calls to avoid hammering the GPU
         time.sleep(0.5)
 
+    return classified
+
 
 def run_test_mode() -> None:
     """Classify the built-in sample articles and exit — useful for smoke-testing."""
@@ -115,7 +136,11 @@ def run_test_mode() -> None:
     print("=" * 60 + "\n")
 
     detector = spike_detector.SpikeDetector()
-    process_articles(_TEST_ARTICLES, detector)
+
+    # Save test articles as raw, then classify from raw pipeline
+    storage.save_raw_articles(_TEST_ARTICLES)
+    classified = classify_pending(detector)
+    print(f"\nClassified {classified} test articles.")
 
     print("\n--- 24h Summary ---")
     for row in storage.summary():
@@ -166,8 +191,12 @@ def run_monitor() -> None:
                 log.debug("Outside market hours — skipping news fetch")
             else:
                 log.info("--- Fetching news ---")
-                article_list = feeds.fetch_all()
-                process_articles(article_list, detector)
+                feeds.fetch_all()  # saves to raw_articles
+
+            # Classify whatever is pending in raw_articles (regardless of market hours)
+            classified = classify_pending(detector)
+            if classified:
+                log.info("Classified %d new articles", classified)
 
             # Periodic summary
             rows = storage.summary()

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -101,18 +101,21 @@ def classify_pending(detector: spike_detector.SpikeDetector) -> int:
         result = classifier.classify(article)
         level  = result.get("classification", "LOW")
 
-        alerts.alert_article(article, result)
         saved = storage.save_event(article, result)
 
         if not saved:
-            # DB write failed — leave cursor here so this article is retried next cycle
-            log.error("Skipping cursor advance for article id=%s due to save failure", article["id"])
-            continue
+            # DB write failed — stop the batch so a later success cannot advance
+            # the cursor past this article; it will be retried next cycle.
+            log.error("Stopping batch at article id=%s due to save failure — will retry next cycle", article["id"])
+            break
 
         # Advance cursor immediately — if we crash on the next article,
         # this one won't be reprocessed
         storage.advance_cursor(article["id"])
         classified += 1
+
+        # Alert only after successful persistence
+        alerts.alert_article(article, result)
 
         is_new_surge = detector.record(article, level)
         if is_new_surge:
@@ -137,9 +140,17 @@ def run_test_mode() -> None:
 
     detector = spike_detector.SpikeDetector()
 
-    # Save test articles as raw, then classify from raw pipeline
-    storage.save_raw_articles(_TEST_ARTICLES)
-    classified = classify_pending(detector)
+    # Classify test articles directly — bypass the persistent cursor so
+    # test mode is deterministic regardless of prior run state.
+    classified = 0
+    for article in _TEST_ARTICLES:
+        if storage.already_seen(article["title"]):
+            continue
+        result = classifier.classify(article)
+        storage.save_event(article, result)
+        alerts.alert_article(article, result)
+        classified += 1
+        time.sleep(0.5)
     print(f"\nClassified {classified} test articles.")
 
     print("\n--- 24h Summary ---")

--- a/core/storage.py
+++ b/core/storage.py
@@ -12,11 +12,13 @@ import hashlib
 import json
 import logging
 from datetime import datetime, timezone, timedelta
+from typing import Optional
 from sqlalchemy import func
+from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.exc import IntegrityError
 
 from . import config
-from .db import get_session, NewsEvent, Feed, Meta, MarketSnapshot, init_db
+from .db import get_session, RawArticle, NewsEvent, Feed, Meta, MarketSnapshot, init_db
 
 log = logging.getLogger(__name__)
 
@@ -26,13 +28,18 @@ def initialize():
     init_db()
 
 
-def save_event(article: dict, result: dict) -> None:
-    """Write a classified article to MySQL and the JSON log file."""
+def save_event(article: dict, result: dict) -> bool:
+    """Write a classified article to MySQL and the JSON log file.
+
+    Returns True if the MySQL write succeeded, False on failure.
+    The JSON log write is best-effort and does not affect the return value.
+    """
     now = datetime.now(timezone.utc)
     pub = article.get("published_at")
     pub_dt = pub if isinstance(pub, datetime) else datetime.fromisoformat(str(pub)) if pub else now
 
     session = get_session()
+    db_ok = False
     try:
         # --- MySQL ---
         event = NewsEvent(
@@ -48,6 +55,7 @@ def save_event(article: dict, result: dict) -> None:
         )
         session.add(event)
         session.commit()
+        db_ok = True
     except Exception as e:
         log.error("MySQL write failed: %s", e)
         session.rollback()
@@ -72,8 +80,10 @@ def save_event(article: dict, result: dict) -> None:
     except Exception as e:
         log.error("Log file write failed: %s", e)
 
+    return db_ok
 
-def get_meta(key: str) -> str | None:
+
+def get_meta(key: str) -> Optional[str]:
     """Return a value from the meta table, or None if not set."""
     session = get_session()
     try:
@@ -281,3 +291,86 @@ def get_market_history(symbol: str, hours: int = 24) -> list[dict]:
         return []
     finally:
         session.close()
+
+
+# ---------------------------------------------------------------------------
+# Raw article pipeline
+# ---------------------------------------------------------------------------
+
+def save_raw_articles(articles: list[dict]) -> int:
+    """Insert raw fetched articles, skipping duplicates. Returns count inserted.
+
+    Uses MySQL INSERT IGNORE so duplicate title_hash rows are silently skipped
+    without rolling back successfully inserted rows in the same batch.
+    """
+    if not articles:
+        return 0
+    now = datetime.now(timezone.utc)
+    rows = []
+    for article in articles:
+        title = article.get("title", "").strip()
+        if not title:
+            continue
+        pub = article.get("published_at")
+        pub_dt = pub if isinstance(pub, datetime) else (
+            datetime.fromisoformat(str(pub)) if pub else now
+        )
+        rows.append({
+            "title_hash": hashlib.sha256(title.lower().encode()).hexdigest(),
+            "title": title,
+            "source": article.get("source", ""),
+            "url": article.get("url", ""),
+            "summary": article.get("summary", ""),
+            "published_at": pub_dt,
+            "fetched_at": now,
+        })
+    if not rows:
+        return 0
+    session = get_session()
+    try:
+        stmt = mysql_insert(RawArticle).prefix_with("IGNORE").values(rows)
+        result = session.execute(stmt)
+        session.commit()
+        return result.rowcount
+    except Exception as e:
+        log.error("Raw article batch write failed: %s", e)
+        session.rollback()
+        return 0
+    finally:
+        session.close()
+
+
+CURSOR_KEY = "monitor_last_processed_id"
+
+
+def get_unclassified_articles(batch_size: int = 50) -> list[dict]:
+    """Return up to batch_size raw articles not yet processed by the monitor.
+
+    Uses an ID-based cursor stored in meta.monitor_last_processed_id. Ordering
+    by id (auto-increment) is unambiguous — no timestamp collision issues.
+    """
+    cursor_str = get_meta(CURSOR_KEY)
+    last_id = 0
+    if cursor_str:
+        try:
+            last_id = int(cursor_str)
+        except (ValueError, TypeError):
+            log.warning("Invalid cursor value '%s' — resetting to 0", cursor_str)
+            set_meta(CURSOR_KEY, "0")
+
+    session = get_session()
+    try:
+        rows = session.query(RawArticle).filter(
+            RawArticle.id > last_id
+        ).order_by(RawArticle.id).limit(batch_size).all()
+        return [r.to_dict() for r in rows]
+    except Exception as e:
+        log.error("Unclassified articles query failed: %s", e)
+        return []
+    finally:
+        session.close()
+
+
+def advance_cursor(article_id: int) -> None:
+    """Advance the classification cursor to the id of the last processed article."""
+    set_meta(CURSOR_KEY, str(article_id))

--- a/core/storage.py
+++ b/core/storage.py
@@ -25,9 +25,14 @@ log = logging.getLogger(__name__)
 
 
 def _title_hash(title: str) -> str:
-    """SHA256 of a fully-normalized title — used as the dedup key in raw_articles."""
+    """SHA256 of a fully-normalized title — used as the dedup key in raw_articles.
+
+    Falls back to hashing the lowercased original if normalization produces an
+    empty string (e.g. titles that are entirely non-ASCII or punctuation), so
+    distinct titles always produce distinct hashes.
+    """
     normalized = re.sub(r"[^a-z0-9 ]", "", title.lower()).strip()
-    return hashlib.sha256(normalized.encode()).hexdigest()
+    return hashlib.sha256((normalized or title.lower()).encode()).hexdigest()
 
 
 def initialize():
@@ -50,13 +55,13 @@ def save_event(article: dict, result: dict) -> bool:
     try:
         # --- MySQL ---
         event = NewsEvent(
-            title=article.get("title", ""),
-            source=article.get("source", ""),
-            url=article.get("url", ""),
+            title=article.get("title", "")[:500],
+            source=article.get("source", "")[:100],
+            url=article.get("url", "")[:1000],
             published_at=pub_dt,
             classification=result.get("classification", "LOW"),
             confidence=result.get("confidence", 0.0),
-            reason=result.get("reason", ""),
+            reason=result.get("reason", "")[:500],
             sentiment=result.get("sentiment"),
             created_at=now,
         )

--- a/core/storage.py
+++ b/core/storage.py
@@ -11,6 +11,7 @@ forwarder pointed at financial_news.log, sourcetype=financial_news.
 import hashlib
 import json
 import logging
+import re
 from datetime import datetime, timezone, timedelta
 from typing import Optional
 from sqlalchemy import func
@@ -21,6 +22,12 @@ from . import config
 from .db import get_session, RawArticle, NewsEvent, Feed, Meta, MarketSnapshot, init_db
 
 log = logging.getLogger(__name__)
+
+
+def _title_hash(title: str) -> str:
+    """SHA256 of a fully-normalized title — used as the dedup key in raw_articles."""
+    normalized = re.sub(r"[^a-z0-9 ]", "", title.lower()).strip()
+    return hashlib.sha256(normalized.encode()).hexdigest()
 
 
 def initialize():
@@ -316,7 +323,7 @@ def save_raw_articles(articles: list[dict]) -> int:
             datetime.fromisoformat(str(pub)) if pub else now
         )
         rows.append({
-            "title_hash": hashlib.sha256(title.lower().encode()).hexdigest(),
+            "title_hash": _title_hash(title),
             "title": title,
             "source": article.get("source", ""),
             "url": article.get("url", ""),


### PR DESCRIPTION
Closes #26

## Summary
- Adds a `raw_articles` table as a persistent buffer between the RSS fetcher and Ollama classifier
- Articles are saved to the database immediately on fetch — before any Ollama call — so a crash mid-classification no longer loses raw data
- The monitor classifies from `raw_articles` using an ID-based cursor (`meta.monitor_last_processed_id`), advancing per-article only on successful DB write

## Architecture
```
Fetcher (fetch_all)
  → INSERT IGNORE into raw_articles (dedup via title_hash UNIQUE)

Monitor (classify_pending)
  → SELECT WHERE id > cursor ORDER BY id LIMIT 50
  → Ollama classify
  → save_event() → returns bool
  → advance cursor only if save succeeded
```

## Crash recovery
A crash mid-batch leaves the cursor behind. On restart the monitor resumes from the last successfully persisted article. No data loss.

## Changes
| File | Change |
|---|---|
| core/db.py | Add RawArticle model |
| core/storage.py | save_raw_articles() (INSERT IGNORE), get_unclassified_articles() (ID cursor), advance_cursor(), save_event() returns bool |
| core/feeds.py | fetch_all() saves to raw_articles, returns inserted count |
| core/monitor.py | Replace process_articles() with classify_pending() |

## Testing
- Ran python -m core.monitor --test locally against MySQL
- Verified cursor correctly picks up new articles and skips already-processed ones
- Verified cursor does not advance when save_event() fails

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>