### PR TITLE
fix: add UTC timezone to datetime serialization

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -92,13 +92,13 @@ class NewsEvent(Base):
             "title": self.title,
             "source": self.source,
             "url": self.url,
-            "published_at": self.published_at.isoformat() if self.published_at else None,
+            "published_at": self.published_at.replace(tzinfo=timezone.utc).isoformat() if self.published_at else None,
             "classification": self.classification,
             "confidence": self.confidence,
             "reason": self.reason,
             "sentiment": self.sentiment,
             "actual_impact": self.actual_impact,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "created_at": self.created_at.replace(tzinfo=timezone.utc).isoformat() if self.created_at else None,
         }
 
 
@@ -121,7 +121,7 @@ class Feed(Base):
             "name": self.name,
             "feed_type": self.feed_type,
             "active": self.active,
-            "added_at": self.added_at.isoformat() if self.added_at else None,
+            "added_at": self.added_at.replace(tzinfo=timezone.utc).isoformat() if self.added_at else None,
         }  # Note: url_hash is intentionally excluded (internal field)
 
 
@@ -167,7 +167,7 @@ class MarketSnapshot(Base):
             "change_pct": self.change_pct,
             "high": self.high,
             "low": self.low,
-            "fetched_at": self.fetched_at.isoformat() if self.fetched_at else None,
+            "fetched_at": self.fetched_at.replace(tzinfo=timezone.utc).isoformat() if self.fetched_at else None,
         }
 
 


### PR DESCRIPTION
## Problem
MySQL `DATETIME` columns return naive Python datetime objects (no timezone info). When serialized via `.isoformat()`, they produce strings like `"2026-04-16T03:52:31"` — no `+00:00` suffix. JavaScript's `new Date("2026-04-16T03:52:31")` treats timezone-less ISO strings as **local time**, causing timestamps to display incorrectly in the UI (appearing in the future for US users).

## Fix
Add `.replace(tzinfo=timezone.utc)` before `.isoformat()` on all datetime fields in `NewsEvent`, `Feed`, and `MarketSnapshot` `to_dict()` methods. The API now returns `"2026-04-16T03:52:31+00:00"` which browsers correctly parse as UTC and convert to the user's local timezone.

## Affected fields
- `NewsEvent`: `published_at`, `created_at`
- `Feed`: `added_at`
- `MarketSnapshot`: `fetched_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)