### PR TITLE
fix: route ordering and modal positioning (missed in PR #34 squash)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -324,19 +324,6 @@ def get_sentiment_timeseries(
     return SentimentTimeseriesResponse(labels=buckets, scores=scores)
 
 
-@router.get("/events/{event_id}", response_model=NewsEventDetail, responses={404: {"description": _NOT_FOUND}})
-def get_event_detail(
-    event_id: int,
-    session: Annotated[Session, Depends(get_db)],
-):
-    """Return full detail for a single event, including the raw RSS summary."""
-    row = session.get(NewsEventModel, event_id)
-    if row is None:
-        raise HTTPException(status_code=404, detail=_NOT_FOUND)
-    data = row.to_dict()
-    return NewsEventDetail(**data)
-
-
 @router.get("/config", response_model=ConfigResponse)
 def get_config():
     """Frontend display settings derived from server config."""
@@ -417,6 +404,19 @@ def get_narrative(session: Annotated[Session, Depends(get_db)]):
     cs.set_meta("narrative_surge_state", str(surge_active))
 
     return NarrativeResponse(text=text, generated_at=now_str, cached=False, surge_active=surge_active)
+
+
+@router.get("/events/{event_id}", response_model=NewsEventDetail, responses={404: {"description": _NOT_FOUND}})
+def get_event_detail(
+    event_id: int,
+    session: Annotated[Session, Depends(get_db)],
+):
+    """Return full detail for a single event, including the raw RSS summary."""
+    row = session.get(NewsEventModel, event_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND)
+    data = row.to_dict()
+    return NewsEventDetail(**data)
 
 
 @router.get("/feeds", response_model=list[FeedInfo])

--- a/frontend/src/components/EventFeed.vue
+++ b/frontend/src/components/EventFeed.vue
@@ -35,8 +35,14 @@ const modalError  = ref(null)
 // Drive native <dialog> open/close from modalOpen
 watch(modalOpen, async (val) => {
   await nextTick()
-  if (val) dialogEl.value?.showModal()
-  else dialogEl.value?.close()
+  if (val) {
+    dialogEl.value?.showModal()
+    // showModal() triggers an internal focus() which scrolls the page.
+    // Immediately re-focus with preventScroll to suppress that scroll.
+    dialogEl.value?.querySelector('.modal-close')?.focus({ preventScroll: true })
+  } else {
+    dialogEl.value?.close()
+  }
 })
 
 async function openModal(ev) {
@@ -199,7 +205,13 @@ small { display: block; color: #555; font-size: 0.78rem; margin-top: 3px; }
   max-height: 80vh;
   overflow-y: auto;
   padding: 24px 28px;
-  position: relative;
+  /* Fixed + transform centers the dialog and gives position: absolute children
+     (the close button) a containing block. Overrides the browser default which
+     would place the dialog at its document-flow position (top-left). */
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   color: #ddd;
 }
 .modal::backdrop {


### PR DESCRIPTION
## What happened

Two commits were pushed to `feat/event-detail-modal` after `--auto` merge was triggered. GitHub squashed and merged the branch at its earlier state, leaving these out of main:

- `1dd3e34` fix: center modal and prevent scroll-to-top on open
- `7fe9348` fix: move /events/{event_id} after all specific /events/* routes

## What this fixes

- **422 on `/api/events/narrative`** — `{event_id}` was registered before `/events/narrative`, causing FastAPI to try parsing "narrative" as an int
- **Modal top-left positioning** — `position: relative` was overriding the browser's top-layer centering; replaced with `position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%)`
- **Scroll-to-top on modal open** — `showModal()` triggers an internal `focus()` which scrolled the page; suppressed with `preventScroll: true`

## Changes

- `api/main.py` — moved `GET /events/{event_id}` to after all static `/events/*` routes
- `frontend/src/components/EventFeed.vue` — modal centering and scroll fix

Closes the regressions introduced by #34.