### PR TITLE
feat: inject prediction into narrative prompt for tone alignment

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -395,7 +395,17 @@ def get_narrative(session: Annotated[Session, Depends(get_db)]):
         except Exception:
             pass
 
-    text = classifier.summarize(events, surge_active=surge_active, market_context=market_ctx)
+    # Pull cached prediction so the LLM can calibrate its tone to match
+    prediction = None
+    try:
+        import json as _json
+        cached_prediction = cs.get_meta("prediction_result")
+        if cached_prediction:
+            prediction = _json.loads(cached_prediction)
+    except Exception:
+        pass
+
+    text = classifier.summarize(events, surge_active=surge_active, market_context=market_ctx, prediction=prediction)
     now_str = datetime.now(timezone.utc).isoformat()
 
     cs.set_meta("narrative_text", text)

--- a/core/classifier.py
+++ b/core/classifier.py
@@ -2,6 +2,7 @@
 
 import re
 import logging
+from typing import Optional
 
 import requests
 
@@ -138,7 +139,7 @@ You are a financial news analyst at a large brokerage firm.
 Recent classified news events (last 24 hours):
 {events}
 
-{surge_context}Write 3-4 sentences covering:
+{prediction_context}{surge_context}Write 3-4 sentences covering:
 - The main financial themes driving market attention right now
 - Why brokerage customers are likely logging in to check their accounts
 - Any key risk factors or catalysts to watch
@@ -146,17 +147,29 @@ Recent classified news events (last 24 hours):
 Rules: Output ONLY the summary sentences. No preamble, no intro phrase, no labels. Start directly with the first sentence of analysis.
 SUMMARY:"""
 
+_PREDICTION_TONE = {
+    "NORMAL":   "metrics indicate baseline login activity — acknowledge themes but note conditions are not yet driving elevated traffic",
+    "MODERATE": "metrics indicate moderately elevated login activity — convey developing conditions that merit attention",
+    "ELEVATED": "metrics indicate significantly elevated login activity — convey meaningful concern and heightened customer engagement",
+    "SURGE":    "metrics indicate a login volume SURGE — convey urgency and directly explain what is driving the spike",
+}
+
 
 def summarize(
     events: list[dict],
     surge_active: bool = False,
     market_context: list[dict] | None = None,
+    prediction: Optional[dict] | None = None,
 ) -> str:
     """Generate a plain-English narrative summary of recent events via Ollama.
 
     If *market_context* is provided (a list of snapshot dicts with at least
     ``name`` and ``change_pct`` keys), significant moves are appended to the
     prompt so the LLM can weave them into the narrative.
+
+    If *prediction* is provided (a dict with at least ``label``, ``score``,
+    and ``drivers`` keys), the current login volume prediction is injected so
+    the LLM calibrates its tone to match the quantitative assessment.
     """
     if not events:
         return "No significant financial events in the last 24 hours."
@@ -184,9 +197,24 @@ def summarize(
                 "\n\nGLOBAL MARKET CONTEXT:\n" + "\n".join(market_lines) + "\n"
             )
 
+    # Inject prediction context so the LLM's tone matches the quantitative view
+    prediction_context = ""
+    if prediction:
+        label   = prediction.get("label", "NORMAL")
+        score   = prediction.get("score", 0)
+        drivers = prediction.get("drivers") or []
+        tone    = _PREDICTION_TONE.get(label, _PREDICTION_TONE["NORMAL"])
+        drivers_str = "; ".join(drivers) if drivers else "no significant drivers"
+        prediction_context = (
+            f"CURRENT LOGIN VOLUME PREDICTION: {label} (score: {score}/100)\n"
+            f"Key drivers: {drivers_str}\n"
+            f"Tone guidance: {tone}\n\n"
+        )
+
     prompt = _SUMMARY_PROMPT.format(
         events="\n".join(lines) + market_section,
         surge_context=surge_context,
+        prediction_context=prediction_context,
     )
     try:
         raw = _call_ollama(prompt)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -219,3 +219,24 @@ class TestSummarize:
         with patch("core.classifier._call_ollama", side_effect=RuntimeError("offline")):
             result = summarize(self._EVENTS)
         assert "unavailable" in result.lower()
+
+    def test_prediction_context_included_in_prompt(self):
+        prediction = {"label": "ELEVATED", "score": 42, "drivers": ["3 HIGH events", "Market volatility"]}
+        captured = {}
+        def capture_prompt(prompt):
+            captured["prompt"] = prompt
+            return "Summary."
+        with patch("core.classifier._call_ollama", side_effect=capture_prompt):
+            summarize(self._EVENTS, prediction=prediction)
+        assert "ELEVATED" in captured["prompt"]
+        assert "42" in captured["prompt"]
+        assert "3 HIGH events" in captured["prompt"]
+
+    def test_no_prediction_context_when_omitted(self):
+        captured = {}
+        def capture_prompt(prompt):
+            captured["prompt"] = prompt
+            return "Summary."
+        with patch("core.classifier._call_ollama", side_effect=capture_prompt):
+            summarize(self._EVENTS)
+        assert "LOGIN VOLUME PREDICTION" not in captured["prompt"]


### PR DESCRIPTION
## Problem

The narrative and prediction were computed from the same event data but never informed each other. The LLM could describe significant geopolitical risk and market volatility while the prediction simultaneously reported NORMAL conditions — neither was wrong, but together they were confusing.

## Solution

The cached prediction (label, score, drivers) is now passed into the `summarize()` prompt as an explicit tone guidance block:

```
CURRENT LOGIN VOLUME PREDICTION: NORMAL (score: 9/100)
Key drivers: 1 MEDIUM event in window; Moderate market volatility: CAC 40
Tone guidance: metrics indicate baseline login activity — acknowledge themes but note conditions are not yet driving elevated traffic
```

The LLM receives a different tone instruction for each prediction level:
| Level | Guidance |
|-------|----------|
| NORMAL | Acknowledge themes but note baseline activity |
| MODERATE | Convey developing conditions that merit attention |
| ELEVATED | Convey meaningful concern and heightened engagement |
| SURGE | Convey urgency, explain the spike directly |

## Changes

- `core/classifier.py` — `summarize()` accepts optional `prediction` dict; builds tone context block
- `api/main.py` — loads `prediction_result` from meta cache and passes it in (no extra DB query)
- `tests/test_classifier.py` — two new tests: prediction context present and absent

## Test plan
- [x] 195 tests pass
- [x] Prediction context appears in prompt when supplied
- [x] No regression when prediction is omitted